### PR TITLE
Add Require for Psych

### DIFF
--- a/lib/stripe_tester.rb
+++ b/lib/stripe_tester.rb
@@ -2,6 +2,7 @@ require "stripe_tester/version"
 require 'uri'
 require 'net/http'
 require 'json'
+require 'psych'
 
 module StripeTester
 


### PR DESCRIPTION
I was getting the following error when I tried to run .create_event:

```
NameError: uninitialized constant StripeTester::Psych
```

I noticed that a simple `require 'psych'` fixed this, so I added it.
