### PR TITLE
Support attribute overwriting in #load_template

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ StripeTester.create_event(:customer_subscription_created, {"data"=>{"object"=>{"
 json = StripeTester.load_template(:invoice_payment_failed)
 ```
 
+  You can also overwrite certain attributes in the JSON:
+```ruby
+json = StripeTester.load_template(:invoice_payment_failed, {"data"=>{"object"=>{"customer"=>"cus_MYCUSTOMERID"}}}, :method=>:merge)
+```
+
 ## Supported Webhooks 
 
 Version 2014-10-07:


### PR DESCRIPTION
These commits add support overwriting attributes in JSON loaded from #load_template. I found this useful for generating webhook JSON bodies in my rails test suite.