### PR TITLE
Authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ In your test:
     StripeTester.stripe_version = "2015-10-16"
 ```
 
-4. Send the webhook. This will send a POST request to the URL with the event data as JSON:
+4. If you are using username and password in your stripe webhook event, you can provide it in two ways.
+```ruby
+    StripeTester.webhook_passord = "<password>"
+    or
+    you can set it in your webhook_url itself like this
+    # Normal HTTP URL
+    StripeTester.webhook_url = "http://stripe:password@www.example.com/my_post_url"
+
+    # HTTPS URL
+    StripeTester.webhook_url = "https://stripe:password@www.secure-example.com/my_post_url"
+```
+
+5. Send the webhook. This will send a POST request to the URL with the event data as JSON:
 ```ruby
     # as a symbol
     StripeTester.create_event(:invoice_created)

--- a/lib/stripe_tester.rb
+++ b/lib/stripe_tester.rb
@@ -56,6 +56,14 @@ module StripeTester
     original_attributes
   end
 
+  def self.authentication_password( post_url )
+    @webhook_password ? @webhook_password : post_url.password
+  end
+
+  def self.password_verification_required?( post_url )
+    @webhook_password.present? or !post_url.password.blank?
+  end
+
   def self.post_to_url(data={})
     post_url = webhook_url
 
@@ -64,6 +72,9 @@ module StripeTester
       req = Net::HTTP::Post.new(post_url.path)
       req.content_type = 'application/json'
       req.body = data.to_json
+      if password_verification_required?( post_url )
+        req.basic_auth 'stripe', authentication_password(post_url)
+      end
 
       http_object = Net::HTTP.new(post_url.hostname, post_url.port)
       http_object.use_ssl = true if post_url.scheme == 'https'
@@ -123,6 +134,14 @@ module StripeTester
 
   def self.remove_url
     @url = nil
+  end
+
+  def self.webhook_password=(webhook_password)
+    @webhook_password = webhook_password
+  end
+
+  def self.webhook_password
+    @webhook_password ? @webhook_password : nil
   end
 
   def self.stripe_version=(version)

--- a/lib/stripe_tester.rb
+++ b/lib/stripe_tester.rb
@@ -61,7 +61,7 @@ module StripeTester
   end
 
   def self.password_verification_required?( post_url )
-    @webhook_password.present? or !post_url.password.blank?
+    @webhook_password or post_url.password
   end
 
   def self.post_to_url(data={})

--- a/spec/stripe_tester_spec.rb
+++ b/spec/stripe_tester_spec.rb
@@ -57,6 +57,23 @@ describe StripeTester do
       expect(result_url.to_s).to eq(url)
     end
 
+    it "#webhook_url should set the correct url if authentication is provided in url itself" do
+      url = 'http://abc:def@www.google.com'
+      StripeTester.webhook_url = url
+
+      result_url = StripeTester.webhook_url
+      expect(result_url.to_s).to eq(url)
+    end
+
+    it "#webhook_url should have correct url when password is provided through webhook_password" do
+      url = 'http://www.google.com'
+      StripeTester.webhook_url = url
+      StripeTester.webhook_password = 'password'
+
+      result_url = StripeTester.webhook_url
+      expect(result_url.to_s).to eq(url)
+    end
+
     it "#verify_ssl should default to true" do
       result_verify = StripeTester.verify_ssl?
       expect(result_verify).to eq(true)

--- a/spec/stripe_tester_spec.rb
+++ b/spec/stripe_tester_spec.rb
@@ -114,6 +114,37 @@ describe StripeTester do
       expect(response).to be_truthy
     end
 
+    it "#post_to_url should return true when authentication is provided" do
+      data = StripeTester.load_template(:invoice_created)
+      url = "http://localhost:3000/transactions"
+      StripeTester.webhook_url = url
+      StripeTester.webhook_password='password'
+
+      FakeWeb.register_uri(:post,
+                           url,
+                           body: data.to_json,
+                           content_type: 'application/json')
+
+      response = StripeTester.post_to_url(data)
+
+      expect(response).to be_truthy
+    end
+
+    it "#post_to_url should return true when authentication is provided through url" do
+      data = StripeTester.load_template(:invoice_created)
+      url = "http://stripe:password@localhost:3000/transactions"
+      StripeTester.webhook_url = url
+
+      FakeWeb.register_uri(:post,
+                           url,
+                           body: data.to_json,
+                           content_type: 'application/json')
+
+      response = StripeTester.post_to_url(data)
+
+      expect(response).to be_truthy
+    end
+
     it "#post_to_url should raise an error when request fails" do
       data = StripeTester.load_template(:invoice_created)
       url = "http://localhost:3000/"


### PR DESCRIPTION
I was recently working with stripe event gem and to test it started using your gem. I could not test the events with user authentication though which is actually advised by stripe event gem so I thought I would try to add it in this gem.
Added support is:
If you are using username and password in your stripe webhook event, you can provide it in two ways.
```ruby
    StripeTester.webhook_passord = "<password>"
    or
    you can set it in your webhook_url itself like this
    # Normal HTTP URL
    StripeTester.webhook_url = "http://stripe:password@www.example.com/my_post_url"

    # HTTPS URL
    StripeTester.webhook_url = "https://stripe:password@www.secure-example.com/my_post_url"